### PR TITLE
Add a missing END statement in the SSL Vhost Template

### DIFF
--- a/templates/vhost/_ssl.erb
+++ b/templates/vhost/_ssl.erb
@@ -18,6 +18,7 @@
   <%- end -%>
   <%- if @ssl_verify_client -%>
   SSLVerifyClient         <%= @ssl_verify_client %>
+  <%- end -%>
   <%- if @ssl_certs_dir && @ssl_certs_dir != '' -%>
   SSLCACertificatePath    "<%= @ssl_certs_dir %>"
   <%- end -%>


### PR DESCRIPTION
It looks to me like 7bb35c2293c12ce52329a4391fe1f20389efef06 (MODULES-5471) introduced a bug. It adds an IF statement that never ends, causing everything below it to not evaluate properly.